### PR TITLE
Update export_trt.py

### DIFF
--- a/export_trt.py
+++ b/export_trt.py
@@ -1,6 +1,6 @@
 import torch
 import time
-from custom_nodes.ComfyUI_Dwpose_Tensorrt.trt_utilities import Engine
+from trt_utilities import Engine
 
 
 def export_trt(trt_path: str, onnx_path: str, use_fp16: bool):


### PR DESCRIPTION
trt_utilities should be imported directly, as it has already been copied to this repository.